### PR TITLE
Allow users to pass in custom arguments when starting the IDE

### DIFF
--- a/Docker/start_sodalite_ide_container.sh
+++ b/Docker/start_sodalite_ide_container.sh
@@ -1,9 +1,11 @@
+#! /bin/bash
+
 xhost +
 if docker ps -a -f "name=sodalite" | grep sodalite; then
 	echo 'Starting existing Sodalite container'
 	docker start sodalite-ide
 else
 	echo 'Starting a new Sodalite container'
-	docker run --name sodalite-ide -it -d -e DISPLAY=:0 -v /tmp/.X11-unix:/tmp/.X11-unix -v $(pwd)/sodalite.properties:/sodalite/eclipse/sodalite.properties sodalite-ide:latest 
+	docker run --name sodalite-ide -it -d -e DISPLAY=:0 -v /tmp/.X11-unix:/tmp/.X11-unix -v $(pwd)/sodalite.properties:/sodalite/eclipse/sodalite.properties "$@" sodalite-ide:latest 
 fi
 


### PR DESCRIPTION
This PR adds the ability to pass custom arguments to the `start_sodalite_ide_container.sh` script. This is useful if users want to tweak the environment. For example, to add custom bind mounts so they can work on files situated on their local disk/outside the docker container.